### PR TITLE
Making terraform code execute correctly first time.

### DIFF
--- a/exercises/main.tf.completed
+++ b/exercises/main.tf.completed
@@ -89,6 +89,7 @@ resource "null_resource" "configure-cat-app" {
   provisioner "remote-exec" {
     inline = [
       "sudo apt -y update",
+      "sudo apt -y update",
       "sudo apt -y install apache2",
       "sudo systemctl start apache2",
       "sudo chown -R ubuntu:ubuntu /var/www/html",

--- a/exercises/main.tf.completed
+++ b/exercises/main.tf.completed
@@ -89,6 +89,7 @@ resource "null_resource" "configure-cat-app" {
   provisioner "remote-exec" {
     inline = [
       "sudo apt -y update",
+      "sleep 15",
       "sudo apt -y update",
       "sudo apt -y install apache2",
       "sudo systemctl start apache2",

--- a/exercises/main.tf.cowsay
+++ b/exercises/main.tf.cowsay
@@ -89,6 +89,7 @@ resource "null_resource" "configure-cat-app" {
   provisioner "remote-exec" {
     inline = [
       "sudo apt -y update",
+      "sudo apt -y update",
       "sudo apt -y install apache2",
       "sudo systemctl start apache2",
       "sudo chown -R ubuntu:ubuntu /var/www/html",

--- a/exercises/main.tf.cowsay
+++ b/exercises/main.tf.cowsay
@@ -89,6 +89,7 @@ resource "null_resource" "configure-cat-app" {
   provisioner "remote-exec" {
     inline = [
       "sudo apt -y update",
+      "sleep 15",
       "sudo apt -y update",
       "sudo apt -y install apache2",
       "sudo systemctl start apache2",

--- a/exercises/main.tf.start
+++ b/exercises/main.tf.start
@@ -89,6 +89,7 @@ resource "google_compute_network" "hashicat" {
 #   provisioner "remote-exec" {
 #     inline = [
 #       "sudo apt -y update",
+#       "sleep 15",
 #       "sudo apt -y update",
 #       "sudo apt -y install apache2",
 #       "sudo systemctl start apache2",

--- a/exercises/main.tf.start
+++ b/exercises/main.tf.start
@@ -89,6 +89,7 @@ resource "google_compute_network" "hashicat" {
 #   provisioner "remote-exec" {
 #     inline = [
 #       "sudo apt -y update",
+#       "sudo apt -y update",
 #       "sudo apt -y install apache2",
 #       "sudo systemctl start apache2",
 #       "sudo chown -R ubuntu:ubuntu /var/www/html",

--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,7 @@ resource "null_resource" "configure-cat-app" {
   provisioner "remote-exec" {
     inline = [
       "sudo apt -y update",
+      "sudo apt -y update",
       "sudo apt -y install apache2",
       "sudo systemctl start apache2",
       "sudo chown -R ubuntu:ubuntu /var/www/html",

--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,7 @@ resource "null_resource" "configure-cat-app" {
   provisioner "remote-exec" {
     inline = [
       "sudo apt -y update",
+      "sleep 15",
       "sudo apt -y update",
       "sudo apt -y install apache2",
       "sudo systemctl start apache2",


### PR DESCRIPTION
Running "apt -y update" twice ensures that apache packages dependencies are installed and the terraform script runs fine the first time.