### PR TITLE
Academy update

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "google_compute_instance" "hashicat" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-1804-lts"
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "subnet_prefix" {
 
 variable "machine_type" {
   description = "Specifies the GCP instance type."
-  default     = "f1-micro"
+  default     = "g1-small"
 }
 
 variable "height" {


### PR DESCRIPTION
This update brings the OS image from Ubuntu from 18.04 LTS to 22.04 LTS and increases the machine size from f1-micro to g1-small.  The deploy time for the previous config is around 5 minutes and this update reduces that by half.  When used in a live presentation or workshop, this time savings is beneficial.