### PR TITLE
Switching from Ubuntu 18 to 22 in all exercise files

### DIFF
--- a/exercises/main.tf.completed
+++ b/exercises/main.tf.completed
@@ -39,7 +39,7 @@ resource "google_compute_firewall" "http-server" {
 }
 
 resource "tls_private_key" "ssh-key" {
-  algorithm = "RSA"
+  algorithm = "ED25519"
   rsa_bits  = "4096"
 }
 
@@ -50,7 +50,7 @@ resource "google_compute_instance" "hashicat" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-1804-lts"
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
     }
   }
 

--- a/exercises/main.tf.completed
+++ b/exercises/main.tf.completed
@@ -40,7 +40,6 @@ resource "google_compute_firewall" "http-server" {
 
 resource "tls_private_key" "ssh-key" {
   algorithm = "ED25519"
-  rsa_bits  = "4096"
 }
 
 resource "google_compute_instance" "hashicat" {

--- a/exercises/main.tf.cowsay
+++ b/exercises/main.tf.cowsay
@@ -39,7 +39,7 @@ resource "google_compute_firewall" "http-server" {
 }
 
 resource "tls_private_key" "ssh-key" {
-  algorithm = "RSA"
+  algorithm = "ED25519"
   rsa_bits  = "4096"
 }
 
@@ -50,7 +50,7 @@ resource "google_compute_instance" "hashicat" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-1804-lts"
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
     }
   }
 

--- a/exercises/main.tf.cowsay
+++ b/exercises/main.tf.cowsay
@@ -40,7 +40,6 @@ resource "google_compute_firewall" "http-server" {
 
 resource "tls_private_key" "ssh-key" {
   algorithm = "ED25519"
-  rsa_bits  = "4096"
 }
 
 resource "google_compute_instance" "hashicat" {

--- a/exercises/main.tf.start
+++ b/exercises/main.tf.start
@@ -40,7 +40,6 @@ resource "google_compute_network" "hashicat" {
 
 # resource "tls_private_key" "ssh-key" {
 #   algorithm = "ED25519"
-#   rsa_bits  = "4096"
 # }
 
 # resource "google_compute_instance" "hashicat" {

--- a/exercises/main.tf.start
+++ b/exercises/main.tf.start
@@ -39,7 +39,7 @@ resource "google_compute_network" "hashicat" {
 # }
 
 # resource "tls_private_key" "ssh-key" {
-#   algorithm = "RSA"
+#   algorithm = "ED25519"
 #   rsa_bits  = "4096"
 # }
 
@@ -50,7 +50,7 @@ resource "google_compute_network" "hashicat" {
 
 #   boot_disk {
 #     initialize_params {
-#       image = "ubuntu-os-cloud/ubuntu-1804-lts"
+#       image = "ubuntu-os-cloud/ubuntu-2204-lts"
 #     }
 #   }
 

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,6 @@ resource "google_compute_firewall" "http-server" {
 
 resource "tls_private_key" "ssh-key" {
   algorithm = "ED25519"
-  rsa_bits  = "4096"
 }
 
 resource "google_compute_instance" "hashicat" {


### PR DESCRIPTION
Updating Ubuntu lineage from 18-bionic to 22-jammy. The main file had been updated but we missed the cumulative exercises used for testing.